### PR TITLE
Remove audio summary text, keep headphone icon only

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -37,25 +37,25 @@ author_profile: true
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1ryZ8kr0O31zgovuI-kvJQQWqPux05Soh/view?usp=sharing" target="_blank">Evolution of local structural motifs in colloidal quantum dot semiconductor nanocrystals leading to nanofaceting</a></p>
-<p class="pub-meta"><em>Nano Letters</em> &middot; 2023 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Nano Letters</em> &middot; 2023 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2023-evolution-local-structural-motifs.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1wzqFTWlsP6dPBa-PPFQurKTc0Rgqq2Xt/view?usp=sharing" target="_blank">Application of Deep Learning Workflow for Autonomous Grain Size Analysis</a></p>
-<p class="pub-meta"><em>Molecules</em> &middot; 2022 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Molecules</em> &middot; 2022 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2022-deep-learning-grain-size-analysis.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/13hAvNmxscW69zNxvSWhCDrs5FmdE0xlN/view?usp=sharing" target="_blank">Lead Leaching of Perovskite Solar Cells in Aqueous Environments: A Quantitative Investigation</a></p>
-<p class="pub-meta"><em>Solar PRL</em> &middot; 2022 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Solar PRL</em> &middot; 2022 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2022-lead-leaching-perovskite-solar-cells.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/103y1SbEskFDqa7MrQuzWdkbrt_GKZOAB/view?usp=sharing" target="_blank">Anisotropic Thermal Transport in Twisted Bilayer Graphene</a></p>
-<p class="pub-meta"><em>Physical Chemistry Chemical Physics</em> &middot; 2022 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Physical Chemistry Chemical Physics</em> &middot; 2022 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2022-anisotropic-thermal-transport-twisted-bilayer-graphene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
@@ -71,181 +71,181 @@ author_profile: true
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/11kVgmlZoAdcv5B4QQv3ypyRDAvrMspL2/view?usp=sharing" target="_blank">Applications of Machine Learning in Computational Nanotechnology</a></p>
-<p class="pub-meta"><em>Nanotechnology</em> &middot; 2022 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Nanotechnology</em> &middot; 2022 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2022-applications-ml-computational-nanotechnology.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1qG2ANt7HqkCtuRKVIklhf_maoI1qu82Y/view?usp=sharing" target="_blank">Atomistic insights into dynamic growth of pentacene thin films on metal surfaces functionalized with self-assembled monolayers</a></p>
-<p class="pub-meta"><em>Applied Surface Science</em> &middot; 2022 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Applied Surface Science</em> &middot; 2022 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2021-atomistic-insights-pentacene-thin-films.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1IjklU1u_ljwI2bPS1layoIgrZNkFdrjJ/view?usp=sharing" target="_blank">Building an AI-ready RSE Workforce</a></p>
-<p class="pub-meta"><em>rse-hpc-2021</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>rse-hpc-2021</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2021-building-ai-ready-rse-workforce.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1CE-Zwj3lQCKu9uoHOy0hr07lL9v2CNif/view?usp=sharing" target="_blank">Thermal Transport in Organic Semiconductors</a></p>
-<p class="pub-meta"><em>Journal of Applied Physics</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Journal of Applied Physics</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2021-thermal-transport-organic-semiconductors.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1TG8zOVfC4qNf3Man-V8v_VVNavHCIwJS/view?usp=sharing" target="_blank">Application of Artificial Intelligence in Renewable Energy and Decarbonization</a></p>
-<p class="pub-meta"><em>ES Energy &amp; Environment</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>ES Energy &amp; Environment</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2021-ai-renewable-energy-decarbonization.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1pE7umbHz1RcWlIz5YpAXUKgvnoxvTwlr/view?usp=sharing" target="_blank">Molecular Dynamics and Machine Learning in Catalysts</a></p>
-<p class="pub-meta"><em>Catalysts</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Catalysts</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2021-molecular-dynamics-ml-catalysts.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1xoEcLagR_b5ma1jU5wFy3XmKVuj5Nilu/view?usp=sharing" target="_blank">Full-Spectrum Thermal Analysis in Twisted Bilayer Graphene</a></p>
-<p class="pub-meta"><em>Physical Chemistry Chemical Physics</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Physical Chemistry Chemical Physics</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2021-full-spectrum-thermal-twisted-bilayer-graphene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1AcEVYFfYAEEPisRVgxOCoeWjl8AfNH-_/view?usp=sharing" target="_blank">Thermal Boundary Resistance at Graphene-Pentacene Interface Explored by A Data-Intensive Approach</a></p>
-<p class="pub-meta"><em>Nanotechnology</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Nanotechnology</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2021-thermal-boundary-resistance-graphene-pentacene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1pxm9_brr3WYJ8nxofIMnBJYjYlbDMldg/view?usp=sharing" target="_blank">High-Throughput Computations of Cross-Plane Thermal Conductivity in Multilayer Stanene</a></p>
-<p class="pub-meta"><em>International Journal of Heat and Mass Transfer</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>International Journal of Heat and Mass Transfer</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2021-high-throughput-cross-plane-stanene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1mLxrIYwhfRgyEZeE6U4hgvNMiOqZSObp/view?usp=sharing" target="_blank">Improved thermoelectric properties of WS2–WSe2 phononic crystals: insights from first-principles calculations</a></p>
-<p class="pub-meta"><em>Nanoscale</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Nanoscale</em> &middot; 2021 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2021-improved-thermoelectric-ws2-wse2-phononic-crystals.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1L4Ve3W8WaWSMiDQL0IOmuG8vqyqlnQkV/view?usp=sharing" target="_blank">Heat transfer and flow characteristics of microchannels with solid and porous ribs</a></p>
-<p class="pub-meta"><em>Applied Thermal Engineering</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Applied Thermal Engineering</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2020-heat-transfer-microchannels-porous-ribs.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/17EweW9Nadgzq5fmlGGgJbsEOUZMjzIZ1/view?usp=sharing" target="_blank">Molecular Dynamics Study of Anisotropic Behaviors of Water Droplet on Textured Surfaces with Various Energies</a></p>
-<p class="pub-meta"><em>Molecular Physics</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Molecular Physics</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2020-molecular-dynamics-anisotropic-water-droplet.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1Q17yToseN7e714LfYjX_fspsp6Rj7VZG/view?usp=sharing" target="_blank">Enhancement of interfacial thermal transport between metal and organic semiconductor using self-assembled monolayers with different terminal groups</a></p>
-<p class="pub-meta"><em>Journal of Physical Chemistry C</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Journal of Physical Chemistry C</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2020-enhancement-interfacial-thermal-transport-sam.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1M13y3hRmBKk7i4MdwQcBEOhP4QMFxH2y/view?usp=sharing" target="_blank">Rational-Designed Hybrid Aerogels for Ultra-Flyweight Electrochemical Energy Storage</a></p>
-<p class="pub-meta"><em>Journal of Physical Chemistry C</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Journal of Physical Chemistry C</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2020-rational-designed-hybrid-aerogels.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1EN-73QMRvZiZfHs6Xf6MopCdShSfEmdq/view?usp=sharing" target="_blank">Multiphoton Absorption Stimulated Metal Chalcogenide Quantum Dot Solar Cells Under Ambient and Concentrated Irradiance</a></p>
-<p class="pub-meta"><em>Advanced Functional Materials</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Advanced Functional Materials</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2020-multiphoton-absorption-quantum-dot-solar-cells.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1qkzZGnGDhlVAvYpWdG0y652fC6UAy1Ep/view?usp=sharing" target="_blank">Colloidal Quantum Dot Hybrids: An Emerging Class of Materials for Ambient Lighting</a></p>
-<p class="pub-meta"><em>Journal of Materials Chemistry C</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Journal of Materials Chemistry C</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2020-colloidal-quantum-dot-hybrids-ambient-lighting.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1-yeUDVXXA3MfzKhUQgbgpfzQsC2QnE3p/view?usp=sharing" target="_blank">Machine Learning and Artificial Neural Network Accelerated Computational Discoveries in Materials Science</a></p>
-<p class="pub-meta"><em>WIREs Computational Molecular Science</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>WIREs Computational Molecular Science</em> &middot; 2020 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2020-ml-ann-computational-discoveries.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/13AFXU9WvaZb4GgOXrm1eWdUJif5ak3cM/view?usp=sharing" target="_blank">Molecular Interactions Balanced One- and Two-Dimensional Hybrid Nanoarchitectures for High-Performance Supercapacitors</a></p>
-<p class="pub-meta"><em>Physical Chemistry Chemical Physics</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Physical Chemistry Chemical Physics</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-molecular-interactions-hybrid-nanoarchitectures.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1BVcjegkZwG24wnZyaVh1vdW3oNnPLeZ4/view?usp=sharing" target="_blank">Growth of Quantum Dot Coated Core-Shell Anisotropic Nanowires and Their Thermal and Electronic Transport</a></p>
-<p class="pub-meta"><em>Applied Physics Letters</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Applied Physics Letters</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-growth-quantum-dot-nanowires.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1ySpllRX5xI_l2B7n0g52LQXdXKyZ2NOM/view?usp=sharing" target="_blank">Chemically Encoded Self-Organized Quantum Chain Supracrystals with Exceptional Charge and Ion Transport Properties</a></p>
-<p class="pub-meta"><em>Nano Energy</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Nano Energy</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-chemically-encoded-quantum-chain-supracrystals.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/16q70wkrm9svHOPWZ15tKFNlEOpV401yT/view?usp=sharing" target="_blank">Critical Fracture Properties in Puckered and Buckled Arsenene by Molecular Dynamics Simulation</a></p>
-<p class="pub-meta"><em>Physical Chemistry Chemical Physics</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Physical Chemistry Chemical Physics</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-critical-fracture-puckered-buckled-arsenene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1fo4Xv6lQ9qKK6zh75B-HAhhURTNVDABZ/view?usp=sharing" target="_blank">Machine Learning Enabled Prediction of Mechanical Properties of Tungsten Disulfide Monolayer</a></p>
-<p class="pub-meta"><em>ACS Omega</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>ACS Omega</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-ml-mechanical-properties-tungsten-disulfide.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/12c0kijqGKKUxgNFdALvV62PjyUHDUj0R/view?usp=sharing" target="_blank">Mechanical Responses of WSe2 Monolayers: A Molecular Dynamics Study</a></p>
-<p class="pub-meta"><em>Materials Research Express</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Materials Research Express</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-mechanical-responses-wse2-monolayers.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/14MZ9eGvzLXFkTjf9m713s-8ooDSlySMd/view?usp=sharing" target="_blank">Overview of Computational Simulations in Quantum Dots</a></p>
-<p class="pub-meta"><em>Israel Journal of Chemistry</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Israel Journal of Chemistry</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-overview-computational-simulations-quantum-dots.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/135cjpy0XeG1xwKV36J-Po_XvT4CtbtMK/view?usp=sharing" target="_blank">Accelerated Discoveries of Mechanical Properties of Graphene Using Machine Learning and High-Throughput Computation</a></p>
-<p class="pub-meta"><em>Carbon</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Carbon</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-accelerated-discoveries-mechanical-graphene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1205C1SydYCXIFLepqr-7IZ5TqufQvjko/view?usp=sharing" target="_blank">Mechanical Properties of Molybdenum Diselenide Revealed by Molecular Dynamics Simulation and Support Vector Machine</a></p>
-<p class="pub-meta"><em>Physical Chemistry Chemical Physics</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Physical Chemistry Chemical Physics</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-mechanical-properties-molybdenum-diselenide.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1hD--MZAkrm2w7zpOpH6ZmWK64A1WYhT3/view?usp=sharing" target="_blank">Toward Improved Thermal Conductance of Graphene-Polyethylene Composites via Surface Defect Engineering: A Molecular Dynamics Study</a></p>
-<p class="pub-meta"><em>Acta Physico-Chimica Sinica</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Acta Physico-Chimica Sinica</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-improved-thermal-conductance-graphene-polyethylene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1vSOt9J_dsNnpZiDcBepsy5Imy1KedKyv/view?usp=sharing" target="_blank">Water Desalination through Rim Functionalized Carbon Nanotubes</a></p>
-<p class="pub-meta"><em>Journal of Materials Chemistry A</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Journal of Materials Chemistry A</em> &middot; 2019 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2019-water-desalination-rim-functionalized-cnt.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1NrZk_BFOK1-de00kWBua7Egqhpz31fYA/view?usp=sharing" target="_blank">Phonon thermal conduction in a graphene-C3N heterobilayer using molecular dynamics simulations</a></p>
-<p class="pub-meta"><em>Nanotechnology</em> &middot; 2018 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Nanotechnology</em> &middot; 2018 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2018-phonon-thermal-conduction-graphene-c3n.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/1-mUKthEzCdohvYXtTj_1QzqLwKe0oGZ5/view?usp=sharing" target="_blank">Machine Learning and Artificial Neural Network Prediction of Interfacial Thermal Resistance between Graphene and Hexagonal Boron Nitride</a></p>
-<p class="pub-meta"><em>Nanoscale</em> &middot; 2018 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Nanoscale</em> &middot; 2018 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2018-ml-ann-interfacial-thermal-resistance-graphene-hbn.mp3" type="audio/mpeg"></audio></div>
 </div>
 
@@ -386,60 +386,60 @@ author_profile: true
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/0B3Yj4QkZpI-dV2JIVlRIQ2dTNkk/view?usp=sharing" target="_blank">A comprehensive review on the molecular dynamics simulation of the novel thermal properties of graphene</a></p>
-<p class="pub-meta"><em>RSC Advances</em> &middot; 2015 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>RSC Advances</em> &middot; 2015 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2015-comprehensive-review-md-thermal-graphene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/0B3Yj4QkZpI-dcHJxLXU2TXlsczg/view?usp=sharing" target="_blank">Tuning thermal contact conductance at graphene-copper interface via surface nanoengineering</a></p>
-<p class="pub-meta"><em>Nanoscale</em> &middot; 2015 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Nanoscale</em> &middot; 2015 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2015-tuning-thermal-conductance-graphene-copper.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/0B3Yj4QkZpI-db2NRVE9JbWhGZEk/view?usp=sharing" target="_blank">Five orders of magnitude reduction in energy coupling across corrugated graphene/substrate interfaces</a></p>
-<p class="pub-meta"><em>ACS Applied Materials &amp; Interfaces</em> &middot; 2014 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>ACS Applied Materials &amp; Interfaces</em> &middot; 2014 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2014-five-orders-magnitude-energy-coupling-graphene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/0B3Yj4QkZpI-daHJmaEs1eE5WME0/view?usp=sharing" target="_blank">Co-existing heat currents in opposite directions in graphene nanoribbons</a></p>
-<p class="pub-meta"><em>Physics Letters A</em> &middot; 2013 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Physics Letters A</em> &middot; 2013 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2013-co-existing-heat-currents-graphene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/0B3Yj4QkZpI-dYlNka1pNd0dVNFE/view?usp=sharing" target="_blank">Phase change and stress wave in picosecond laser–material interaction with shock wave formation</a></p>
-<p class="pub-meta"><em>Applied Physics A</em> &middot; 2013 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Applied Physics A</em> &middot; 2013 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2013-phase-change-stress-wave-picosecond-laser.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/0B3Yj4QkZpI-dcnZRZzh0Qkt4QkE/view?usp=sharing" target="_blank">Phonon energy inversion in graphene during transient thermal transport</a></p>
-<p class="pub-meta"><em>Physics Letters A</em> &middot; 2013 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Physics Letters A</em> &middot; 2013 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2013-phonon-energy-inversion-graphene.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/0B3Yj4QkZpI-dbDZ5NWVHa1hLQlU/view?usp=sharing" target="_blank">Thermal transport in bent graphene nanoribbons</a></p>
-<p class="pub-meta"><em>Nanoscale</em> &middot; 2013 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Nanoscale</em> &middot; 2013 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2013-thermal-transport-bent-graphene-nanoribbons.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/0B3Yj4QkZpI-dWFl4c3N1US1hS2s/view?usp=sharing" target="_blank">Rough contact is not always bad for interfacial energy coupling</a></p>
-<p class="pub-meta"><em>Nanoscale</em> &middot; 2013 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Nanoscale</em> &middot; 2013 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2013-rough-contact-interfacial-energy-coupling.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/0B3Yj4QkZpI-dUjE4dW54Q09rd0k/view?usp=sharing" target="_blank">Micro/Nanoscale Spatial Resolution Temperature Probing for the Interfacial Thermal Characterization of Epitaxial Graphene on 4H-SiC</a></p>
-<p class="pub-meta"><em>Small</em> &middot; 2011 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Small</em> &middot; 2011 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2011-micro-nanoscale-temperature-probing-graphene-sic.mp3" type="audio/mpeg"></audio></div>
 </div>
 
 <div class="pub-item">
 <p class="pub-title"><a href="https://drive.google.com/file/d/0B3Yj4QkZpI-dY1N1ekprMndvbnc/view?usp=sharing" target="_blank">Dynamic response of graphene to thermal impulse</a></p>
-<p class="pub-meta"><em>Physical Review B</em> &middot; 2011 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i> audio summary</a></p>
+<p class="pub-meta"><em>Physical Review B</em> &middot; 2011 &middot; <a href="#" class="audio-toggle" onclick="event.preventDefault();var a=this.closest('.pub-item').querySelector('.audio-player');a.style.display=a.style.display==='none'?'block':'none';"><i class="fas fa-headphones"></i></a></p>
 <div class="audio-player" style="display:none;"><audio controls preload="none" style="width:100%;margin-top:6px;"><source src="/assets/audio/2011-dynamic-response-graphene-thermal-impulse.mp3" type="audio/mpeg"></audio></div>
 </div>


### PR DESCRIPTION
Remove the \"audio summary\" text from all 44 audio toggle buttons, keeping only the headphone icon for a cleaner interface.