### PR TITLE
Add visitor map widget to home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -67,6 +67,11 @@
       </div>
     </div>
 
+    <!-- Visitor Map - fixed bottom left -->
+    <div style="position: fixed; bottom: 10px; left: 10px; z-index: 50; opacity: 0.6; max-width: 200px;">
+      <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=nKPi-vkEnDdhV9Kn-xwokCjImXp946U433XOrC35O7c&cl=ffffff&w=200"></script>
+    </div>
+
     <div class="page__footer">
       <footer>
         {% include footer/custom.html %}


### PR DESCRIPTION
Add a MapMyVisitors map widget fixed to the lower-left corner of the home page.

- Small (200px), subtle (60% opacity) so it doesn't distract from content
- Tracks visitor locations and displays them on the map
- Stats available at https://mapmyvisitors.com/web/1c33z