### PR TITLE
Fix visitor map position: stop overlapping content on mobile

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -67,8 +67,8 @@
       </div>
     </div>
 
-    <!-- Visitor Map - fixed bottom left -->
-    <div style="position: fixed; bottom: 10px; left: 10px; z-index: 50; opacity: 0.6; max-width: 200px;">
+    <!-- Visitor Map - bottom left, in page flow -->
+    <div style="text-align: left; padding: 1em 1.5em; opacity: 0.6; max-width: 200px;">
       <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=nKPi-vkEnDdhV9Kn-xwokCjImXp946U433XOrC35O7c&cl=ffffff&w=200"></script>
     </div>
 


### PR DESCRIPTION
Fix visitor map overlapping page content on mobile.

- Changed from `position: fixed` (floats over content) to static positioning (in normal page flow)
- Map now sits at the bottom-left of the page, above the footer — users scroll down to see it
- No longer blocks text or other content on mobile screens