### PR TITLE
Shorten IB perf blog post title

### DIFF
--- a/_posts/2026-02-28-IB Perf Drop Investigation.md
+++ b/_posts/2026-02-28-IB Perf Drop Investigation.md
@@ -1,6 +1,6 @@
 ---
 layout: single
-title: "Debugging InfiniBand Performance Degradation Caused by Background GPU Stress Tests"
+title: "GPU Stress Tests Degraded InfiniBand Performance"
 author_profile: false
 ---
 


### PR DESCRIPTION
Shorten the blog post title from 10 words to 6 words:\n\n- **Before:** \"Debugging InfiniBand Performance Degradation Caused by Background GPU Stress Tests\"\n- **After:** \"GPU Stress Tests Degraded InfiniBand Performance\"\n\nKeeps \"GPU Stress Tests\" to distinguish from future IB perf posts.