### PR TITLE
Fix broken script links: blob/main → blob/master

### DIFF
--- a/_posts/2026-01-25-Fine-Tuning Across NVLink and InfiniBand.md
+++ b/_posts/2026-01-25-Fine-Tuning Across NVLink and InfiniBand.md
@@ -351,7 +351,7 @@ The Azure ND H100 v5 VMs with 8× NDR InfiniBand are well-suited for multi-node 
 
 ## Reproducing These Results
 
-All code is available: the [benchmark script](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/main/scripts/fsdp-multinode/finetune_bench.py), [launch script](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/main/scripts/fsdp-multinode/launch_node.sh), and [orchestration script](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/main/scripts/fsdp-multinode/run_multinode.sh) work on any Azure ND H100 v5 VMSS cluster (or similar multi-node GPU setup with InfiniBand). The only requirements are:
+All code is available: the [benchmark script](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/master/scripts/fsdp-multinode/finetune_bench.py), [launch script](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/master/scripts/fsdp-multinode/launch_node.sh), and [orchestration script](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/master/scripts/fsdp-multinode/run_multinode.sh) work on any Azure ND H100 v5 VMSS cluster (or similar multi-node GPU setup with InfiniBand). The only requirements are:
 
 - Docker with NVIDIA runtime
 - Passwordless SSH between nodes

--- a/_posts/2026-02-15-IB vs Ethernet Fine-Tuning at Scale.md
+++ b/_posts/2026-02-15-IB vs Ethernet Fine-Tuning at Scale.md
@@ -376,7 +376,7 @@ That said, the data does show that for teams fine-tuning 7B–13B models on a mo
 
 The cluster runs on Azure with 10× Standard_ND96isr_H100_v5 VMs in a VMSS, with an 8 TiB Azure Managed Lustre filesystem mounted at `/lustre` on every node. See [this post]({% post_url 2026-02-09-AMLFS with GPU VMSS %}) for the cluster setup.
 
-Scripts: [finetune_bench.py](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/main/scripts/ib-vs-eth/finetune_bench.py), [launch_node.sh](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/main/scripts/ib-vs-eth/launch_node.sh), [run_multinode.sh](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/main/scripts/ib-vs-eth/run_multinode.sh), [sweep.sh](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/main/scripts/ib-vs-eth/sweep.sh).
+Scripts: [finetune_bench.py](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/master/scripts/ib-vs-eth/finetune_bench.py), [launch_node.sh](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/master/scripts/ib-vs-eth/launch_node.sh), [run_multinode.sh](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/master/scripts/ib-vs-eth/run_multinode.sh), [sweep.sh](https://github.com/JingchaoZhang/JingchaoZhang.github.io/blob/master/scripts/ib-vs-eth/sweep.sh).
 
 To run a single experiment:
 


### PR DESCRIPTION
Script hyperlinks in two blog posts pointed to `blob/main/` but the repo's default branch is `master`, causing 404 errors when readers clicked them.

**Changes:**
- `2026-02-15-IB vs Ethernet Fine-Tuning at Scale.md` — fix 4 links (`finetune_bench.py`, `launch_node.sh`, `run_multinode.sh`, `sweep.sh`)
- `2026-01-25-Fine-Tuning Across NVLink and InfiniBand.md` — fix 3 links (`finetune_bench.py`, `launch_node.sh`, `run_multinode.sh`)